### PR TITLE
doc: add minimal documentation for solving system and retrieving results

### DIFF
--- a/src/result.mli
+++ b/src/result.mli
@@ -7,6 +7,18 @@
 module type S = sig
   module Core : CoreSig.S
   val get : (Core.P.t * bool) option -> Core.t -> Core.result
+  (** [get (objective, is_max_bounded) env] retrieves the result from a simplex [env].
+
+      This needs to be called after the system [env] has been solved by {!module-SolveBounds}.
+
+      @param objective the optimization objective if any
+      @param is_max_bounded whether the result is bounded
+      @param env the simplex environment (system of linear inequalities) containing the solution
+
+      @return solution that satisfies the constraints if any
+  *)
+
+
 end
 
 module Make(Core : CoreSig.S) : S with module Core = Core

--- a/src/solveBounds.mli
+++ b/src/solveBounds.mli
@@ -8,8 +8,20 @@ val src : Logs.src
 
 module type S = sig
   module Core : CoreSig.S
+
   val solve : Core.t -> Core.t
+  (** [solve env] solves the linear inequalities in the simplex [env].
+
+    Use {!module-Result} to retrieve the solution if any.
+   *)
+
   val maximize : Core.t -> Core.P.t -> Core.t * (Core.P.t * bool) option
+  (** [maximize env objective] finds the maximum value of [objective] that satisfies the system of linear inequalities in [env].
+
+    Use {!module-Result} to retrieve the solution if any.
+
+    @return env,(objective,is_max_bounded)
+   *)
 end
 
 module Make(Core : CoreSig.S) : S with module Core = Core


### PR DESCRIPTION
This can be inferred from tests/*.ml, but it is better to have some minimal documentation on what the parameters mean.

Especially that solving the system returns the same type that was given as input (i.e. the environment is mutable).

This is my attempt to improve the documentation slightly based on what I could infer from the tests, please correct me if it is wrong or note entirely accurate.