### PR TITLE
Separate type for coefficient and value

### DIFF
--- a/src/basic.ml
+++ b/src/basic.ml
@@ -13,7 +13,8 @@ module Make
 
   module Core : CoreSig.S
     with module Var=Var
-     and module R=R
+     and type R.t = R.t
+     and type V.t = R.t
      and module Ex=Ex
 
   module Assert : AssertBounds.S with module Core := Core

--- a/src/basic.mli
+++ b/src/basic.mli
@@ -16,7 +16,8 @@ module Make
       and some functions to handle them. *)
   module Core : CoreSig.S
     with module Var=Var
-     and module R=R
+     and type R.t=R.t
+     and type V.t = R.t
      and module Ex=Ex
 
   module Assert : AssertBounds.S with module Core := Core

--- a/src/core.ml
+++ b/src/core.ml
@@ -11,17 +11,20 @@ let src = Logs.Src.create "OcplibSimplex.Core" ~doc:"The Core of the simplex sol
 
 module MakeExpert
     (Var : Variables)
-    (R   : Rationals)
+    (R   : Coefs)
+    (V   : Value with type r = R.t)
     (Ex  : Explanations)
-    (R2  : Rat2.SIG with module R = R)
+    (R2  : Rat2.SIG with module R = R and module V = V)
     (P  : Polys.SIG with module Var = Var and module R = R)
     (MX : MapSig with type key = Var.t)
     (SX : SetSig with type elt = Var.t)
-  : CoreSig.S with module Var=Var and module R=R and module Ex=Ex and
-  module P = P and module MX = MX and module SX = SX = struct
+  : CoreSig.S with module Var=Var and module R=R and module V = V
+                                  and module Ex=Ex and
+                   module P = P and module MX = MX and module SX = SX = struct
 
   module Var = Var
   module R   = R
+  module V = V
   module Ex  = Ex
 
   module R2  = R2
@@ -48,10 +51,10 @@ module MakeExpert
     }
 
   type solution = {
-    main_vars : (Var.t * R.t) list;
-    slake_vars : (Var.t * R.t) list;
+    main_vars : (Var.t * V.t) list;
+    slake_vars : (Var.t * V.t) list;
     int_sol : bool; (* always set to false for rational simplexes*)
-    epsilon : R.t;
+    epsilon : V.t;
   }
 
   type maximum =
@@ -262,7 +265,7 @@ module MakeExpert
       let aux fmt l =
         List.iter
           (fun (x, q) ->
-             fprintf fmt "  %a --> %a@." Var.print x R.print q;
+             fprintf fmt "  %a --> %a@." Var.print x V.print q;
           )l
       in
       fun is_int fmt s ->
@@ -414,7 +417,7 @@ module MakeExpert
            let v = info.value in
            assert (not (violates_min_bound v info.mini));
            assert (not (violates_max_bound v info.maxi));
-           assert (not int_sol || R.is_int v.R2.v && R.is_zero v.R2.offset)
+           assert (not int_sol || V.is_int v.R2.v && R.is_zero v.R2.offset)
         ) mx
     in
     match result with
@@ -579,6 +582,13 @@ module Make
     (Var : Variables)
     (R   : Rationals)
     (Ex  : Explanations)
-  : CoreSig.S with module Var=Var and module R=R and module Ex=Ex =
-  MakeExpert(Var)(R)(Ex)(Rat2.Make(R))(Polys.Make(Var)(R))
+  : CoreSig.S with module Var=Var and type R.t = R.t and type V.t = R.t and module Ex=Ex = struct
+  module V' = struct
+    include R
+    type r = t
+    let mult_by_coef = mult
+    let div_by_coef = div
+  end
+  include MakeExpert(Var)(R)(V')(Ex)(Rat2.Make(R)(V'))(Polys.Make(Var)(R))
     (Map.Make(Var))(Set.Make(Var))
+end

--- a/src/core.mli
+++ b/src/core.mli
@@ -14,18 +14,20 @@ module Make
   (Ex  : Explanations)
   : CoreSig.S
     with module Var = Var
-     and module R = R
+     and type R.t = R.t
+     and type V.t = R.t
      and module Ex = Ex
 
 module MakeExpert
     (Var : Variables)
-    (R   : Rationals)
+    (R   : Coefs)
+    (V   : Value with type r = R.t)
     (Ex  : Explanations)
-    (R2  : Rat2.SIG with module R = R)
+    (R2  : Rat2.SIG with module R = R and module V = V)
     (P  : Polys.SIG with module Var = Var and module R = R)
     (MX : MapSig with type key = Var.t)
     (SX : SetSig with type elt = Var.t)
-  : CoreSig.S with module Var=Var and module R=R and module Ex=Ex and
+  : CoreSig.S with module Var=Var and module R=R and module V=V and module Ex=Ex and
   module P = P and module MX = MX and module SX = SX
 (** Same than Make but allows to choose the implementation of polynomials, maps
     and sets *)

--- a/src/core.mli
+++ b/src/core.mli
@@ -16,3 +16,16 @@ module Make
     with module Var = Var
      and module R = R
      and module Ex = Ex
+
+module MakeExpert
+    (Var : Variables)
+    (R   : Rationals)
+    (Ex  : Explanations)
+    (R2  : Rat2.SIG with module R = R)
+    (P  : Polys.SIG with module Var = Var and module R = R)
+    (MX : MapSig with type key = Var.t)
+    (SX : SetSig with type elt = Var.t)
+  : CoreSig.S with module Var=Var and module R=R and module Ex=Ex and
+  module P = P and module MX = MX and module SX = SX
+(** Same than Make but allows to choose the implementation of polynomials, maps
+    and sets *)

--- a/src/coreSig.mli
+++ b/src/coreSig.mli
@@ -22,11 +22,14 @@ module type S = sig
       initializing the simplex core. *)
   module Ex  : Explanations
 
-  (** The interface for rationals provided by users. *)
-  module R   : Rationals
+  (** The interface for rationals provided by users for the coefficient. *)
+  module R   : Coefs
+
+  (** The interface for values of variable and bounds provided by users. *)
+  module V   : Value with type r = R.t
 
   (** Pairs of rationals R representing bounds with an offset [x + kƐ]. *)
-  module R2  : Rat2.SIG with module R = R
+  module R2  : Rat2.SIG with module R = R and module V = V
 
   (** Linear relations of variables. *)
   module P : Polys.SIG with module Var = Var and module R = R
@@ -59,10 +62,10 @@ module type S = sig
     }
 
   type solution = {
-    main_vars : (Var.t * R.t) list;
-    slake_vars : (Var.t * R.t) list;
+    main_vars : (Var.t * V.t) list;
+    slake_vars : (Var.t * V.t) list;
     int_sol : bool; (* Always set to false for rational simplexes. *)
-    epsilon : R.t;
+    epsilon : V.t;
   }
 
   type maximum = {

--- a/src/coreSig.mli
+++ b/src/coreSig.mli
@@ -32,8 +32,8 @@ module type S = sig
   module P : Polys.SIG with module Var = Var and module R = R
 
   (** Collections of variables. *)
-  module MX : Map.S with type key = Var.t
-  module SX : Set.S with type elt = Var.t
+  module MX : MapSig with type key = Var.t
+  module SX : SetSig with type elt = Var.t
 
   (*module SLAKE : Map.S with type key = P.t*)
 

--- a/src/extSigs.mli
+++ b/src/extSigs.mli
@@ -64,3 +64,33 @@ module type Explanations = sig
   val union : t -> t -> t
   val print : Format.formatter -> t -> unit
 end
+
+module type MapSig = sig
+  type 'a t
+  type key
+
+  val empty : 'a t
+  val find : key -> 'a t -> 'a
+  val add : key -> 'a -> 'a t -> 'a t
+  val remove : key -> 'a t -> 'a t
+  val mem: key -> 'a t -> bool
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+  val cardinal : 'a t -> int
+end
+
+module type SetSig = sig
+  type t
+  type elt
+
+  val empty : t
+  val is_empty : t -> bool
+  val choose : t -> elt
+  val elements : t -> elt list
+  val add : elt -> t -> t
+  val mem : elt -> t -> bool
+  val remove : elt -> t -> t
+  val fold : (elt -> 'b -> 'b) -> t -> 'b -> 'b
+  val iter : (elt -> unit) -> t -> unit
+  val union : t -> t -> t
+end

--- a/src/extSigs.mli
+++ b/src/extSigs.mli
@@ -55,6 +55,63 @@ module type Rationals = sig
   val ceiling : t -> t
 end
 
+(** Interface required for coefs *)
+module type Coefs = sig
+
+  (** type of rationnal numbers *)
+  type t
+  val zero : t
+  val one : t
+  val m_one : t
+  val sign : t -> int (* can be used to quickly compare with zero *)
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val is_zero : t -> bool
+  val is_one : t -> bool
+  val is_m_one : t -> bool
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val div : t -> t -> t
+  val mult : t -> t -> t
+  val abs : t -> t
+  val is_int : t -> bool
+  val print : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val min : t -> t -> t
+  val minus : t -> t
+  val floor : t -> t
+  val ceiling : t -> t
+end
+
+(** Interface required for bounds and solutions *)
+module type Value = sig
+
+  (** type of rationnal numbers *)
+  type t
+  val zero : t
+  val one : t
+  val m_one : t
+  val sign : t -> int (* can be used to quickly compare with zero *)
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val is_zero : t -> bool
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val div : t -> t -> t
+  val mult : t -> t -> t
+  val is_int : t -> bool
+  val print : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val min : t -> t -> t
+  val minus : t -> t
+  val floor : t -> t
+  val ceiling : t -> t
+
+  type r
+  val mult_by_coef: t -> r -> t
+  val div_by_coef: t -> r -> t
+end
+
 (*----------------------------------------------------------------------------*)
 
 (** Interface of explanations *)

--- a/src/extSigs.mli
+++ b/src/extSigs.mli
@@ -79,8 +79,6 @@ module type Coefs = sig
   val to_string : t -> string
   val min : t -> t -> t
   val minus : t -> t
-  val floor : t -> t
-  val ceiling : t -> t
 end
 
 (** Interface required for bounds and solutions *)
@@ -97,8 +95,6 @@ module type Value = sig
   val is_zero : t -> bool
   val add : t -> t -> t
   val sub : t -> t -> t
-  val div : t -> t -> t
-  val mult : t -> t -> t
   val is_int : t -> bool
   val print : Format.formatter -> t -> unit
   val to_string : t -> string

--- a/src/polys.ml
+++ b/src/polys.ml
@@ -8,7 +8,7 @@ open ExtSigs
 
 module type SIG = sig
   module Var : Variables
-  module R : Rationals
+  module R : Coefs
 
   type t
   type var_status = New | Exists | Removed

--- a/src/polys.mli
+++ b/src/polys.mli
@@ -8,7 +8,7 @@ open ExtSigs
 
 module type SIG = sig
   module Var : Variables
-  module R : Rationals
+  module R : Coefs
 
   type t
   type var_status = New | Exists | Removed

--- a/src/rat2.ml
+++ b/src/rat2.ml
@@ -20,7 +20,6 @@ module type SIG = sig
   val minus : t -> t
   val add : t -> t -> t
   val sub : t -> t -> t
-  val mult : t -> t -> t
   val mult_by_const : R.t -> t -> t
   val div_by_const : R.t -> t -> t
 
@@ -63,7 +62,6 @@ module Make(R : Rationals)(V : Value with type r = R.t)
 
   let add  = map2 V.add R.add
   let sub  = map2 V.sub R.sub
-  let mult = map2 V.mult R.mult
 
   let mult_by_const c e =
     if R.is_one c then e

--- a/src/rat2.ml
+++ b/src/rat2.ml
@@ -7,14 +7,15 @@
 open ExtSigs
 
 module type SIG = sig
-  module R : Rationals
+  module R : Coefs
+  module V : Value with type r = R.t
 
-  type t = private {v: R.t; offset: R.t}
+  type t = private {v: V.t; offset: R.t}
 
   val zero : t
-  val of_r : R.t -> t
-  val upper : R.t -> t
-  val lower : R.t -> t
+  val of_r : V.t -> t
+  val upper : V.t -> t
+  val lower : V.t -> t
 
   val minus : t -> t
   val add : t -> t -> t
@@ -35,12 +36,14 @@ module type SIG = sig
   val print : Format.formatter -> t -> unit
 end
 
-module Make(R : Rationals) : SIG with module R = R = struct
+module Make(R : Rationals)(V : Value with type r = R.t)
+  : SIG with module R = R and module V = V = struct
 
   module R = R
+  module V = V
 
   type t = {
-    v: R.t;
+    v: V.t;
 
     offset: R.t;
     (* When working on strict bounds, an epsilon is added to the bounds.
@@ -50,51 +53,51 @@ module Make(R : Rationals) : SIG with module R = R = struct
   let of_r v = {v; offset = R.zero}
   let upper v = {v; offset = R.m_one}
   let lower v = {v; offset = R.one}
-  let zero = of_r R.zero
+  let zero = of_r V.zero
 
   let is_pure_rational r = R.equal r.offset R.zero
-  let is_int r = is_pure_rational r && R.is_int r.v
+  let is_int r = is_pure_rational r && V.is_int r.v
 
-  let map f a = {v = f a.v; offset = f a.offset}
-  let map2 f a b = {v = f a.v b.v; offset = f a.offset b.offset}
+  let map f g a = {v = f a.v; offset = g a.offset}
+  let map2 f g a b = {v = f a.v b.v; offset = g a.offset b.offset}
 
-  let add  = map2 R.add
-  let sub  = map2 R.sub
-  let mult = map2 R.mult
+  let add  = map2 V.add R.add
+  let sub  = map2 V.sub R.sub
+  let mult = map2 V.mult R.mult
 
   let mult_by_const c e =
     if R.is_one c then e
-    else map (R.mult c) e
+    else map (fun v -> V.mult_by_coef v c) (fun v -> R.mult v c) e
 
   let div_by_const c e =
     if R.is_one c then e
-    else map (fun v -> R.div v c) e
+    else map (fun v -> V.div_by_coef v c) (fun v -> R.div v c) e
 
   let compare a b =
-    let c = R.compare a.v b.v in
+    let c = V.compare a.v b.v in
     if c <> 0 then c else R.compare a.offset b.offset
 
   let equal a b = compare a b = 0
 
-  let is_zero a = R.is_zero a.v && R.is_zero a.offset
+  let is_zero a = V.is_zero a.v && R.is_zero a.offset
 
-  let minus = map R.minus
+  let minus = map V.minus R.minus
 
   let floor r =
-    if R.is_int r.v
+    if V.is_int r.v
     then
       if is_pure_rational r
       then r
-      else of_r (R.sub r.v R.one)
-    else of_r (R.floor r.v)
+      else of_r (V.sub r.v V.one)
+    else of_r (V.floor r.v)
 
   let ceiling r =
-    if R.is_int r.v
+    if V.is_int r.v
     then
       if is_pure_rational r
       then r
-      else of_r (R.add r.v R.one)
-    else of_r (R.ceiling r.v)
+      else of_r (V.add r.v V.one)
+    else of_r (V.ceiling r.v)
 
   let print_offset fmt off =
     let c = R.compare off R.zero in
@@ -104,6 +107,6 @@ module Make(R : Rationals) : SIG with module R = R = struct
     else Format.fprintf fmt "%aƐ" R.print off
 
   let print fmt r = Format.fprintf fmt "%a%a"
-      R.print r.v
+      V.print r.v
       print_offset r.offset
 end

--- a/src/rat2.mli
+++ b/src/rat2.mli
@@ -16,12 +16,13 @@
 open ExtSigs
 
 module type SIG = sig
-  module R : Rationals
+  module R : Coefs
+  module V : Value with type r = R.t
 
   (** {1 Type} *)
 
   type t = private {
-    v: R.t;
+    v: V.t;
     (** The raw value of the bound. *)
 
     offset: R.t
@@ -34,13 +35,13 @@ module type SIG = sig
   val zero : t
 
   (** From a rational [r], returns the Rat2 representation with no offset. *)
-  val of_r : R.t -> t
+  val of_r : V.t -> t
 
   (** From a rational [r], returns [r - Ɛ]. *)
-  val upper : R.t -> t
+  val upper : V.t -> t
 
   (** From a rational [r], returns [r + Ɛ]. *)
-  val lower : R.t -> t
+  val lower : V.t -> t
 
   (** {1 Algebraic operations} *)
 
@@ -92,4 +93,4 @@ module type SIG = sig
   val print : Format.formatter -> t -> unit
 end
 
-module Make(R : Rationals) : SIG with module R = R
+module Make(R : Rationals)(V : Value with type r = R.t) : SIG with module R = R and module V = V

--- a/src/rat2.mli
+++ b/src/rat2.mli
@@ -54,9 +54,6 @@ module type SIG = sig
   (** Substracts two bounds. *)
   val sub : t -> t -> t
 
-  (** Multiplies two bounds. *)
-  val mult : t -> t -> t
-
   (** Multiplies a bound by a rational constant 
       (both v and offset are multiplied). *)
   val mult_by_const : R.t -> t -> t


### PR DESCRIPTION
Mostly is adds `Core.MakeExpert` functor, and keep the backward compatibility. Except for `Rat2.Make` that I don't think is used by external users.

It is interesting to not that not the same functions are needed for coefficient and values.