### PR TITLE
Remove dependency on num

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,7 @@
   (ocaml (>= 4.02.0))
   (dune (>= 2.0))
   (ocamlfind (>= 1.9.1))
-  num
+  (zarith :with-test)
   (logs (>= 0.5.0))
 ))
 

--- a/ocplib-simplex.opam
+++ b/ocplib-simplex.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "2.0"}
   "ocamlfind" {>= "1.9.1"}
-  "num"
+  "zarith" {with-test}
   "logs" {>= "0.5.0"}
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,6 @@
 (library
  (name OcplibSimplex)
  (public_name ocplib-simplex)
- (libraries num logs)
+ (libraries logs)
  (modules_without_implementation coreSig extSigs)
 )

--- a/tests/dune
+++ b/tests/dune
@@ -10,7 +10,7 @@
    standalone_minimal_maximization
    standalone_minimal
    standalone_test_strict_bounds)
- (libraries ocplib-simplex))
+ (libraries ocplib-simplex zarith))
 
 (rule
  (alias runtest)

--- a/tests/simplex.ml
+++ b/tests/simplex.ml
@@ -15,32 +15,30 @@ module Var = struct
 end
 
 module Rat = struct
-  open Num
+  type t = Q.t
+  let add = Q.add
+  let minus = Q.neg
+  let mult = Q.mul
+  let abs = Q.abs
+  let compare = Q.compare
+  let equal = Q.equal
+  let zero = Q.zero
+  let one = Q.one
+  let m_one = Q.minus_one
+  let is_zero n = Q.equal n Q.zero
+  let to_string = Q.to_string
 
-  type t = num
-  let add = ( +/ )
-  let minus = minus_num
-  let mult = ( */ )
-  let abs = abs_num
-  let compare = compare_num
-  let equal = ( =/ )
-  let zero = Int 0
-  let one = Int 1
-  let m_one = Int (-1)
-  let is_zero n = n =/ zero
-  let to_string = string_of_num
+  let print = Q.pp_print
+  let is_int v = Z.equal (Q.den v) Z.one
+  let div = Q.div
+  let sub = Q.sub
+  let is_one v = Q.equal v Q.one
+  let is_m_one v = Q.equal v Q.minus_one
+  let sign = Q.sign
+  let min = Q.min
 
-  let print fmt t = Format.fprintf fmt "%s" (to_string t)
-  let is_int = is_integer_num
-  let div = (//)
-  let sub = (-/)
-  let is_one v = v =/ Int 1
-  let is_m_one v = v =/ Int (-1)
-  let sign = sign_num
-  let min = min_num
-
-  let floor = floor_num
-  let ceiling = ceiling_num
+  let floor v = Z.fdiv (Q.num v) (Q.den v) |> Q.of_bigint
+  let ceiling v = Z.cdiv (Q.num v) (Q.den v) |> Q.of_bigint
 
 end
 

--- a/tests/standalone_minimal_maximization.ml
+++ b/tests/standalone_minimal_maximization.ml
@@ -1,9 +1,9 @@
 
 open Simplex
 
-let large i = Sim.Core.R2.of_r (Num.Int i)
-let upper i = Sim.Core.R2.upper (Num.Int i)
-let lower i = Sim.Core.R2.lower (Num.Int i)
+let large i = Sim.Core.R2.of_r (Q.of_int i)
+let upper i = Sim.Core.R2.upper (Q.of_int i)
+let lower i = Sim.Core.R2.lower (Q.of_int i)
 
 let bnd r e = {Sim.Core.bvalue = r; explanation = e}
 

--- a/tests/standalone_test_strict_bounds.ml
+++ b/tests/standalone_test_strict_bounds.ml
@@ -39,9 +39,9 @@ let aux sim opt_p =
   sep ();
   Format.printf "@."
 
-let large i = Sim.Core.R2.of_r (Num.Int i)
-let upper i = Sim.Core.R2.upper (Num.Int i)
-let lower i = Sim.Core.R2.lower (Num.Int i)
+let large i = Sim.Core.R2.of_r (Q.of_int i)
+let upper i = Sim.Core.R2.upper (Q.of_int i)
+let lower i = Sim.Core.R2.lower (Q.of_int i)
 
 let bnd r e = {Sim.Core.bvalue = r; explanation = e}
 


### PR DESCRIPTION
ocplib-simplex is written as a functor to allow for dependency injection, so there is no good reason to depend on Num except to run the tests.

Moreover, the tests are written using Num, which has been deprecated for a long time, so this patch also switches them to use ZArith instead.