### PR TITLE
Bump the minimal version of `Dune` to `3.0`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 3.0)
 (generate_opam_files true)
 
 (name ocplib-simplex)
@@ -23,7 +23,7 @@
  (license "LGPL-2.1-or-later")
  (depends
   (ocaml (>= 4.02.0))
-  (dune (>= 2.0))
+  (dune (>= 3.0))
   (ocamlfind (>= 1.9.1))
   (zarith :with-test)
   (logs (>= 0.5.0))

--- a/ocplib-simplex.opam
+++ b/ocplib-simplex.opam
@@ -19,14 +19,14 @@ doc: "https://ocamlpro.github.io/ocplib-simplex"
 bug-reports: "https://github.com/OCamlPro/ocplib-simplex/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "3.0" & >= "3.0"}
   "ocamlfind" {>= "1.9.1"}
   "zarith" {with-test}
   "logs" {>= "0.5.0"}
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/tests/standalone_minimal_maximization.ml
+++ b/tests/standalone_minimal_maximization.ml
@@ -1,9 +1,6 @@
-
 open Simplex
 
 let large i = Sim.Core.R2.of_r (Q.of_int i)
-let upper i = Sim.Core.R2.upper (Q.of_int i)
-let lower i = Sim.Core.R2.lower (Q.of_int i)
 
 let bnd r e = {Sim.Core.bvalue = r; explanation = e}
 


### PR DESCRIPTION
The generated opam files by `Dune < 3.0` isn't correct when calling `dune subst`. See issue https://github.com/ocaml/dune/pull/3647.

This commit bumps the minimal version to `3.0`.